### PR TITLE
Use both BLTouch and Z-Stop

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -162,7 +162,7 @@
   /**
    * Auto Bed Leveling and Z Probe Repeatability Test
    */
-  #define HOMING_Z_WITH_PROBE (HAS_BED_PROBE && Z_HOME_DIR < 0 && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN))
+  #define HOMING_Z_WITH_PROBE (HAS_BED_PROBE && Z_HOME_DIR < 0)
 
   /**
    * Z Sled Probe requires Z_SAFE_HOMING

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -38,6 +38,7 @@
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 #define CONFIGURATION_H_VERSION 010107
+#define ADVi3PP_BLTOUCH
 
 // This is only to ensure that CLion is parsing code properly inside the IDE
 #ifdef __CLION_IDE__
@@ -648,6 +649,7 @@
 #ifdef ADVi3PP_BLTOUCH
 // BLTouch probe uses Z-Max endstop
 #define Z_MIN_PROBE_ENDSTOP
+#define Z_MIN_PROBE_PIN Z_MAX_PIN
 #endif
 
 /**
@@ -1084,7 +1086,7 @@
 // - Prevent Z homing when the Z probe is outside bed area.
 //
 // We are still using the z-min endstop and people do not like much the safe homing in the middle of the bed
-//#define Z_SAFE_HOMING
+#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -38,7 +38,6 @@
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 #define CONFIGURATION_H_VERSION 010107
-#define ADVi3PP_BLTOUCH
 
 // This is only to ensure that CLion is parsing code properly inside the IDE
 #ifdef __CLION_IDE__


### PR DESCRIPTION
Enabled Safe homing (homing done in center of bed)

Allows z-stop to occur with BLTouch as well as z-switch (for safety)

A WIP, but feel free to merge and or implement in your own way. 