### PR TITLE
Prevent sticking of filament during unload process

### DIFF
--- a/Marlin/advi3pp.cpp
+++ b/Marlin/advi3pp.cpp
@@ -1091,7 +1091,8 @@ void Printer_::unload_filament_start_task()
     {
         Log::log() << F("Unload Filament") << Log::endl();
         LCD::buzz(100); // Inform the user that the un-extrusion starts
-        enqueue_and_echo_commands_P(PSTR("G1 E-1 F120"));
+        enqueue_and_echo_commands_P(PSTR("G1 E3 F120")); //extrude 5mm to avoid sticking
+        enqueue_and_echo_commands_P(PSTR("G1 E-1 F120")); //continue to unload filament
         task_.set_background_task(BackgroundTask(this, &Printer_::unload_filament_task));
         LCD::set_status(F("Wait until the filament comes out..."));
     }


### PR DESCRIPTION
Extrudes 3mm of a filament to "unstick" filament from hotend, then continues with unloading process. 

I've been having issues during filament change where the filament will get stuck and not back out unless I first "load" for a short period of time, then "unload" right after.

Please note the comment of 5mm is incorrect, forgot to change it back to 3mm.
5mm was too much.