### PR TITLE
Add MarkII BLTouch config

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -767,15 +767,6 @@
 //#define MANUAL_PROBE_START_Z 0.2
 
 /**
- * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
- *   (e.g., an inductive probe or a nozzle-based probe-switch.)
- */
-// @advi3++: Mark II probe is fix
-#ifdef ADVi3PP_MARK2
-#define FIX_MOUNTED_PROBE
-#endif
-
-/**
  * Z Servo Probe, such as an endstop switch on a rotating arm.
  */
 //#define Z_PROBE_SERVO_NR 0   // Defaults to SERVO 0 connector.
@@ -794,6 +785,17 @@
 #define ADVi3PP_BLTOUCH
 #define BLTOUCH
 #define BLTOUCH_V3
+#endif
+
+/**
+ * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
+ *   (e.g., an inductive probe or a nozzle-based probe-switch.)
+ */
+// @advi3++: Mark II probe is fix
+#ifndef BLTOUCH
+#ifdef ADVi3PP_MARK2
+#define FIX_MOUNTED_PROBE
+#endif
 #endif
 
 #if ENABLED(BLTOUCH)

--- a/Marlin/pins_I3_PLUS_MARK2.h
+++ b/Marlin/pins_I3_PLUS_MARK2.h
@@ -39,6 +39,9 @@
 #define Y_STOP_PIN         24   // PA2 / AD2
 #define Z_STOP_PIN         6    // PH3 / PCINT8
 #define Z_MIN_PROBE_PIN    6    // PH3 / PCINT8
+#ifdef ADVi3PP_BLTOUCH
+    #define SERVO0_PIN     7   // PH4
+#endif
 
 //
 // Steppers

--- a/platformio.ini
+++ b/platformio.ini
@@ -106,6 +106,17 @@ monitor_speed      = ${common.monitor_speed}
 upload_protocol    = ${common.upload_protocol}
 upload_flags       = ${common.upload_flags}
 
+[env:i3plus-mark2-bltouch3]
+platform           = ${common.platform}
+board              = ${common.board}
+framework          = ${common.framework}
+build_flags        = ${common.build_flags} -D ADVi3PP_MARK2 -D ADVi3PP_BLTOUCH3
+board_build.f_cpu  = ${common.board_build.f_cpu}
+monitor_port       = ${common.monitor_port}
+monitor_speed      = ${common.monitor_speed}
+upload_protocol    = ${common.upload_protocol}
+upload_flags       = ${common.upload_flags}
+
 [env:i3plus-mark2-debug]
 platform           = ${common.platform}
 board              = ${common.board}


### PR DESCRIPTION
### Description

Add a PlatformIO environment for a MarkII printer with BLTouch.

Note: This has not yet been extensively tested. It likely makes sense to wait a while before merging so that any issues can be discovered and resolved.

Another note: This configuration assumes the user will use the pins on the interface board like so, assuming the pin numbering scheme from this image: ![image](http://sebastien.andrivet.com/media/images/Interface-board-mark2.width-500.png)

BLTouch | Interface Board
--------|---------
VCC (Red) | VCC (Pin 18)
GND (Brown) | GND (Pin 16)
GND (Black) | GND (Pin 14)
Servo (Orange) | BL (Pin 19/Arduino pin 7/PH4)
Z-Min (White) | Z-Min (Pin 20/Arduino pin 6/PH3)

I set up the connections by soldering a few wires to the contacts on the bottom of the board.

### Benefits

Allows users to replace their inductive MarkII sensor with a BLTouch (e.g. for use with a heated bed).

### Related Issues

[Forum post](https://community.advi3pp.com/t/bl-touch-with-duplicator-i3-plus-mk2/152/).
