### PR TITLE
Fix for showing no sensor error page on non-bltouch board

### DIFF
--- a/Marlin/src/advi3pp/screens/controls/automatic_leveling.cpp
+++ b/Marlin/src/advi3pp/screens/controls/automatic_leveling.cpp
@@ -64,7 +64,7 @@ void AutomaticLeveling::reset_command()
 #ifdef ADVi3PP_PROBE
     core.inject_commands(F("M280 P0 S160"));
 #else
-    pages.show_page(Page::NoSensor);
+    pages.show(Page::NoSensor);
 #endif
 }
 


### PR DESCRIPTION
### Description

I could not build the non-bltouch firmware due to this error.

### Benefits

Builds for non-bltouch

### Related Issues

No related issues
