### PR TITLE
Fix Z offset not saved in Settings -> Sensor page

### DIFF
--- a/Marlin/src/advi3pp/screens/settings/sensor_settings.cpp
+++ b/Marlin/src/advi3pp/screens/settings/sensor_settings.cpp
@@ -167,7 +167,7 @@ void SensorSettings::get_values()
 
     int16_t x = frame.read_signed_word();
     int16_t y = frame.read_signed_word();
-    uint16_t z = frame.read_word();
+    int16_t z = (int16_t)frame.read_word();
 
     ExtUI::setProbeOffset_mm(x / 100.0, ExtUI::X);
     ExtUI::setProbeOffset_mm(y / 100.0, ExtUI::Y);

--- a/Marlin/src/advi3pp/screens/settings/sensor_settings.cpp
+++ b/Marlin/src/advi3pp/screens/settings/sensor_settings.cpp
@@ -167,7 +167,7 @@ void SensorSettings::get_values()
 
     int16_t x = frame.read_signed_word();
     int16_t y = frame.read_signed_word();
-    int16_t z = (int16_t)frame.read_word();
+    int16_t z = frame.read_signed_word();
 
     ExtUI::setProbeOffset_mm(x / 100.0, ExtUI::X);
     ExtUI::setProbeOffset_mm(y / 100.0, ExtUI::Y);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Manual value change of Z offset in Settings -> Probe UI page is not saved.

Issue is in SensorSettings::get_values()
Signed value is loaded to an unsigned variable, that cause wrong positive Z offset, that is obviously out of bounds in ExtUI::setZOffset_mm() and Z offset is not changed.

### Requirements

Affects only if ADVi3PP_PROBE defined.

### Benefits

Fixes #268 and #280

### Related Issues

#280 
#268