### PR TITLE
Fix preheat presets fan speeds

### DIFF
--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1358,7 +1358,7 @@ int16_t getMaterialPresetBedTemp_celsius(unsigned int index)
 
 uint8_t getMaterialPresetFanSpeed_percent(unsigned int index)
 {
-  return thermalManager.fanSpeedPercent(ui.material_preset[index].fan_speed);
+  return ui8_to_percent(ui.material_preset[index].fan_speed);
 }
 
 void setMaterialPreset(unsigned int index, int16_t hotend_celcius, int16_t bed_celcius, uint8_t fan_percent)


### PR DESCRIPTION
### Description

Preheat presets fan speeds result in inconsistent fan speed values after saving.

As of 5.8.0, `getMaterialPresetFanSpeed_percent()` calls `thermalManager.fanSpeedPercent(ui.material_preset[index].fan_speed)`, but `fanSpeedPercent()` expects a fan number value (based on `FAN_COUNT`), not a fan speed value.

### Requirements

5.8.0

### Benefits

Fix preheat presets fan speeds

### Configurations

n/a

### Related Issues

n/a
