### PR TITLE
Adjust build scripts to create necessary directories, reduce spurious warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,7 +181,6 @@ LCD-Panel/Masters/*.png
 LCD-Panel/DGUS-png/
 LCD-Panel/DGUS-root/25_Controls
 LCD-Panel/DGUS-root/DWIN_SET/*.bmp
-LCD-Panel/Export/
 Thumbs.db
 Marlin/Simulator Debug/
 Marlin/Simulator Release/

--- a/LCD-Panel/Export/.gitignore
+++ b/LCD-Panel/Export/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/Scripts/convert-images.sh
+++ b/Scripts/convert-images.sh
@@ -4,6 +4,8 @@ Convert the PNG images into proper bitmaps for the LCD Panel (BMP3).
 Must be called each time the images are modified.
 '
 
+unsetopt nomatch
+
 scripts="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ret=$?; if [[ $ret != 0 ]]; then exit $ret; fi
 
@@ -81,8 +83,8 @@ if ! $quiet ; then
 fi
 
 rm -rf "${png}/DWIN_SET" "${png}/Controls" "${png}/Screenshots"
-rm "${dgus}/DWIN_SET/"*.bmp
-rm "${dgus}/25_Controls/"*.bmp
+rm -f "${dgus}/DWIN_SET/"*.bmp
+rm -f "${dgus}/25_Controls/"*.bmp
 
 copy_images
 convert_images "${png}/Boot"            "${dgus}/DWIN_SET"

--- a/Scripts/create-release.sh
+++ b/Scripts/create-release.sh
@@ -40,7 +40,7 @@ if ! [ -x "$(command -v git)" ]; then
   exit 1
 fi
 
-if ! [ -x "$(command -v convert)" ]; then
+if ! [ -x "$(command -v magick)" ]; then
   echo 'Error: imagemagick is not installed, use: brew install imagemagick' >&2
   exit 1
 fi

--- a/Scripts/excludes.txt
+++ b/Scripts/excludes.txt
@@ -4,3 +4,4 @@
 DWprj.hmi
 DWprj.tft
 Thumbs.db
+/25_Controls/*

--- a/Scripts/generate-boot-images.sh
+++ b/Scripts/generate-boot-images.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+unsetopt nomatch
 
 scripts="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ret=$?; if [[ $ret != 0 ]]; then exit $ret; fi
@@ -9,6 +10,7 @@ ret=$?; if [[ $ret != 0 ]]; then exit $ret; fi
 masters="$( cd "${root}/Masters" && pwd )"
 ret=$?; if [[ $ret != 0 ]]; then exit $ret; fi
 
+mkdir -p "${root}/DGUS-png"
 png="$( cd "${root}/DGUS-png" && pwd )"
 ret=$?; if [[ $ret != 0 ]]; then exit $ret; fi
 


### PR DESCRIPTION
### Description

These are a few tweaks to the build scripts to help streamline building from a freshly cloned repository.

### Requirements

v6.0.2

### Benefits

- Adds 'LCD-Panel/Export' as an empty directory by including a .gitignore to exclude any files inside the directory. This helps when freshly cloning the repository instead of having to manually create the Export directory for the build scripts to run correctly.
- Silences warnings from zsh when attempting to batch delete non-existent files.
- Updates ImagicMagick command from convert to magick.
- Excludes the 'LCD-Panel/DGUS-root/25_Controls' directory from being added to the LCD update .zip archive. Only 'DWIN_SET' is required for the LCD to update.

### Configurations

All

### Related Issues

n/a
